### PR TITLE
Feature/allow custom imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/superset_role/tree/develop)
 
+### :heavy_plus_sign: Added
+
+- Option to add custom imports in superset_config.py
+
 ## [1.1.1](https://github.com/idealista/superset_role/tree/1.1.1) (2021-06-24)
 
 [Full Changelog](https://github.com/idealista/superset_role/compare/1.1.0...1.1.1)

--- a/defaults/main/superset_config.yml
+++ b/defaults/main/superset_config.yml
@@ -2,6 +2,9 @@
 
 # superset_config.py
 
+# User Custom imports
+superset_config_custom_imports: []
+
 superset_stats_logger:
 superset_event_logger:
 superset_log_view: True

--- a/templates/superset_config.j2
+++ b/templates/superset_config.j2
@@ -1,5 +1,11 @@
+{{ ansible_managed | comment }}
+
 from flask_appbuilder.security.manager import {{ superset_auth_type }}
 {% if superset_celerybeat_schedule != "" %}from celery.schedules import crontab{% endif %}
+
+# User Custom imports
+{% for import in superset_config_custom_imports %}{{ import }}
+{% endfor %}
 
 # Realtime stats logger, a StatsD implementation exists
 # STATS_LOGGER =


### PR DESCRIPTION
### Description of the Change

- new var for imports `superset_config_custom_imports`
- required jinja code in templeate

### Benefits

Add new var to set custom imports in `superset_config.py`

### Possible Drawbacks

No drawbacks detected

### Applicable Issues

No applicable issues